### PR TITLE
Fix trimmed display issue of lines containing hard tabs and add mapping config for delete-key

### DIFF
--- a/cmdline.c
+++ b/cmdline.c
@@ -692,7 +692,7 @@ void do_commandline(int argc, char *argv[])
 		}
 		else if (strcmp(argv[loop], "-b") == 0)
 		{
-			tab_width = get_value_arg("-b", argv[++loop], VAL_ZERO_POSITIVE);
+			tab_width = get_value_arg("-b", argv[++loop], VAL_POSITIVE);
 		}
 		else if (strcmp(argv[loop], "-u") == 0)
 		{

--- a/config.c
+++ b/config.c
@@ -845,6 +845,11 @@ void set_xclip(int linenr, char *cmd, char *par)
 	xclip = strdup(par);
 }
 
+void set_map_delete_as_backspace(int linenr, char *cmd, char *par)
+{
+	map_delete_as_backspace = config_yes_no(par);	
+}
+
 void set_searchhistory_file(int linenr, char *cmd, char *par)
 {
 	if (par[0] == 0x00)
@@ -1068,6 +1073,7 @@ config_file_keyword cf_entries[] = {
 	{ "include", do_load_config },
 	{ "inverse", set_inverse_attrs },
 	{ "line_ts_format", set_line_ts_format },
+	{ "map_delete_as_backspace", set_map_delete_as_backspace },
 	{ "markerline_char", set_markerline_char },
 	{ "markerline_color", set_markerline_attrs },
 	{ "markerline_timestamp", set_markerline_timestamp },

--- a/config.c
+++ b/config.c
@@ -729,6 +729,8 @@ void set_check_mail(int linenr, char *cmd, char *par)
 void set_tab_stop(int linenr, char *cmd, char *par)
 {
 	tab_width = atoi(par);
+	if (tab_width == 0)
+		config_error_exit(linenr, "tab_stop: value cannot be 0.\n");
 }
 
 void set_tail(int linenr, char *cmd, char *par)

--- a/globals.c
+++ b/globals.c
@@ -151,6 +151,7 @@ mybool_t posix_tail = 0;
 mybool_t resolv_ip_addresses = 1;
 mybool_t show_severity_facility = 1;
 mybool_t gnu_tail = 0;
+mybool_t map_delete_as_backspace = MY_FALSE;
 
 regex_t global_highlight_re;
 char *global_highlight_str = NULL;

--- a/globals.h
+++ b/globals.h
@@ -142,6 +142,7 @@ extern int syslog_port;
 extern char scrollback_search_new_window;
 extern char *global_find;
 extern mybool_t gnu_tail;
+extern mybool_t map_delete_as_backspace;
 
 void set_do_refresh(char val);
 char get_do_refresh();

--- a/mt.c
+++ b/mt.c
@@ -447,11 +447,9 @@ int draw_tab(NEWWIN *win)
 
 		for(loop=0; loop<move; loop++)
 			waddch(win -> win, ' ');
-
-		return move;
 	}
 
-	return 0;
+	return 1;
 }
 
 

--- a/multitail.conf
+++ b/multitail.conf
@@ -1242,3 +1242,7 @@ scrollback_no_colors:no
 # when you search in the scrollback: open new window with found strings (= on)
 # or jump to the next found (= off)
 scrollback_search_new_window:yes
+#
+# set to (yes) to map delete key as backspace key.
+# this is useful if you are using mac
+map_delete_as_backspace:no

--- a/term.c
+++ b/term.c
@@ -197,6 +197,11 @@ char * edit_string(NEWWIN *win, int win_y, int win_x, int win_width, int max_wid
 			break;
 		}
 
+		/* key modifier */
+		if (c == 127 && map_delete_as_backspace == MY_TRUE) {
+			c = KEY_BACKSPACE;
+		}
+
 		switch(c)
 		{
 		case 1:			/* ^A */


### PR DESCRIPTION
Added another commit to enable mapping delete-key to backspace key for user who is using PC like MacBook Air, which has the behaviour of backspace with delete key.

Current version of multitail may trim the line depending on the line length when there are hard tabs in line. This commit will fix the issue.
Could you please test the issue with following case?

printf '\t\t1\t12\t123\t1234\t12345\t123456\t1234567\t12345678\t1Find-End-Here!\n' | ./multitail -j

Thanks!