### PR TITLE
Missing xclip.o in makefile.macosx

### DIFF
--- a/makefile.macosx
+++ b/makefile.macosx
@@ -6,7 +6,7 @@ DEBUG=#-g -D_DEBUG #-pg #-fprofile-arcs
 LDFLAGS=-lpanel -lncurses -lm $(DEBUG)
 CFLAGS=-O2 -D$(shell uname) -DVERSION=\"$(VERSION)\" $(DEBUG) -DCONFIG_FILE=\"$(CONFIG_FILE)\"
 
-OBJS=utils.o mt.o error.o my_pty.o term.o scrollback.o help.o mem.o cv.o selbox.o stripstring.o color.o misc.o ui.o exec.o diff.o config.o cmdline.o globals.o history.o
+OBJS=utils.o mt.o error.o my_pty.o term.o scrollback.o help.o mem.o cv.o selbox.o stripstring.o color.o misc.o ui.o exec.o diff.o config.o cmdline.o globals.o history.o xclip.o
 
 all: multitail
 


### PR DESCRIPTION
This fixes the compilation on OS X. It doesn’t work without that because `scrollback.c` uses xclip:

```
$ make -f makefile.macosx multitail
cc -O2 -DDarwin -DVERSION=\"6.3\"  -DCONFIG_FILE=\"/etc/multitail.conf\"   -c -o utils.o utils.c
cc -O2 -DDarwin -DVERSION=\"6.3\"  -DCONFIG_FILE=\"/etc/multitail.conf\"   -c -o mt.o mt.c
cc -O2 -DDarwin -DVERSION=\"6.3\"  -DCONFIG_FILE=\"/etc/multitail.conf\"   -c -o error.o error.c
cc -O2 -DDarwin -DVERSION=\"6.3\"  -DCONFIG_FILE=\"/etc/multitail.conf\"   -c -o my_pty.o my_pty.c
cc -O2 -DDarwin -DVERSION=\"6.3\"  -DCONFIG_FILE=\"/etc/multitail.conf\"   -c -o term.o term.c
cc -O2 -DDarwin -DVERSION=\"6.3\"  -DCONFIG_FILE=\"/etc/multitail.conf\"   -c -o scrollback.o scrollback.c
cc -O2 -DDarwin -DVERSION=\"6.3\"  -DCONFIG_FILE=\"/etc/multitail.conf\"   -c -o help.o help.c
cc -O2 -DDarwin -DVERSION=\"6.3\"  -DCONFIG_FILE=\"/etc/multitail.conf\"   -c -o mem.o mem.c
cc -O2 -DDarwin -DVERSION=\"6.3\"  -DCONFIG_FILE=\"/etc/multitail.conf\"   -c -o cv.o cv.c
cc -O2 -DDarwin -DVERSION=\"6.3\"  -DCONFIG_FILE=\"/etc/multitail.conf\"   -c -o selbox.o selbox.c
cc -O2 -DDarwin -DVERSION=\"6.3\"  -DCONFIG_FILE=\"/etc/multitail.conf\"   -c -o stripstring.o stripstring.c
cc -O2 -DDarwin -DVERSION=\"6.3\"  -DCONFIG_FILE=\"/etc/multitail.conf\"   -c -o color.o color.c
cc -O2 -DDarwin -DVERSION=\"6.3\"  -DCONFIG_FILE=\"/etc/multitail.conf\"   -c -o misc.o misc.c
cc -O2 -DDarwin -DVERSION=\"6.3\"  -DCONFIG_FILE=\"/etc/multitail.conf\"   -c -o ui.o ui.c
cc -O2 -DDarwin -DVERSION=\"6.3\"  -DCONFIG_FILE=\"/etc/multitail.conf\"   -c -o exec.o exec.c
cc -O2 -DDarwin -DVERSION=\"6.3\"  -DCONFIG_FILE=\"/etc/multitail.conf\"   -c -o diff.o diff.c
cc -O2 -DDarwin -DVERSION=\"6.3\"  -DCONFIG_FILE=\"/etc/multitail.conf\"   -c -o config.o config.c
cc -O2 -DDarwin -DVERSION=\"6.3\"  -DCONFIG_FILE=\"/etc/multitail.conf\"   -c -o cmdline.o cmdline.c
cc -O2 -DDarwin -DVERSION=\"6.3\"  -DCONFIG_FILE=\"/etc/multitail.conf\"   -c -o globals.o globals.c
cc -O2 -DDarwin -DVERSION=\"6.3\"  -DCONFIG_FILE=\"/etc/multitail.conf\"   -c -o history.o history.c
cc -Wall -W utils.o mt.o error.o my_pty.o term.o scrollback.o help.o mem.o cv.o selbox.o stripstring.o color.o misc.o ui.o exec.o diff.o config.o cmdline.o globals.o history.o -lpanel -lncurses -lm  -o multitail
Undefined symbols for architecture x86_64:
  "_send_to_clipboard", referenced from:
      _scrollback_do in scrollback.o
  "_xclip", referenced from:
      _set_xclip in config.o
     (maybe you meant: _set_xclip)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [multitail] Error 1
```

Note it fixes the compilation but OS X doesn’t have `xclip`. Would you be interested by a pull request to add support for `pbpaste`, the OS X equivalent of `xclip`?

Using the [v6.3](https://github.com/flok99/multitail/releases/tag/v6.3) on OS X 10.10.2.