### PR TITLE
Fix segfault when run within the current working directory

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -353,7 +353,7 @@ char * getusername(void)
 		if (logname)
 		{
 			strncpy(username, logname, 128);
-			logname[127] = 0x00;
+			username[127] = 0x00;
 		}
 	}
 


### PR DESCRIPTION
Ensure the right buffer is null-terminated.