### PR TITLE
[WIP] Added support for pbcopy on OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ LDFLAGS+=-lpanel -lncurses -lutil -lm
 CFLAGS+=-funsigned-char -D`uname` -DVERSION=\"$(VERSION)\" -DCONFIG_FILE=\"$(CONFIG_FILE)\" -D_FORTIFY_SOURCE=2 -O3
 endif
 
-OBJS=utils.o mt.o error.o my_pty.o term.o scrollback.o help.o mem.o cv.o selbox.o stripstring.o color.o misc.o ui.o exec.o diff.o config.o cmdline.o globals.o history.o xclip.o
+OBJS=utils.o mt.o error.o my_pty.o term.o scrollback.o help.o mem.o cv.o selbox.o stripstring.o color.o misc.o ui.o exec.o diff.o config.o cmdline.o globals.o history.o clipboard.o
 
 all: multitail
 

--- a/clipboard.h
+++ b/clipboard.h
@@ -1,0 +1,10 @@
+extern char *clipboard;
+
+#ifdef __APPLE__
+#define CLIPBOARD_NAME "pbcopy"
+#else
+#define CLIPBOARD_NAME "xclip"
+#endif
+
+void send_to_clipboard_binary(char *what);
+void send_to_clipboard(buffer *pb);

--- a/config.c
+++ b/config.c
@@ -22,7 +22,7 @@
 #include "exec.h"
 #include "globals.h"
 #include "config.h"
-#include "xclip.h"
+#include "clipboard.h"
 
 /* "local global" */
 int cur_colorscheme_nr = -1;
@@ -842,7 +842,15 @@ void set_xclip(int linenr, char *cmd, char *par)
 	if (file_exist(par) == -1)
 		error_exit(TRUE, FALSE, "xclip binary '%s' does not exist");
 
-	xclip = strdup(par);
+	clipboard = strdup(par);
+}
+
+void set_pbcopy(int linenr, char *cmd, char *par)
+{
+	if (file_exist(par) == -1)
+		error_exit(TRUE, FALSE, "pbcopy binary '%s' does not exist");
+
+	clipboard = strdup(par);
 }
 
 void set_map_delete_as_backspace(int linenr, char *cmd, char *par)
@@ -1120,7 +1128,10 @@ config_file_keyword cf_entries[] = {
 	{ "warn_closed", set_warn_closed },
 	{ "window_number", set_window_number },
 	{ "wordwrapmaxlength", set_wordwrapmaxlength },
-	{ "xclip", set_xclip }
+	{ "xclip", set_xclip },
+#ifdef __APPLE__
+        { "pbcopy", set_pbcopy },
+#endif
 };
 
 int find_config_entry_in_dispatch_table(char *cmd_name)

--- a/help.c
+++ b/help.c
@@ -601,7 +601,11 @@ char *help_scrollback_help[] = {
 		"lines. This size can be set with the ^-m^ command-",
 		"line parameter or the ^m^-key in the main menu.",
 		" ^c^     set colors",
+#ifdef __APPLE__
+		" ^x^     copy contents to clipboard (pbcopy)",
+#else
 		" ^x^     copy contents to X clipboard (xclip)",
+#endif
 		" ^f^/^/^   search for a string in the buffer",
 		" ^n^     find the next occurence",
 		" ^Y^     toggle linewrap. if linewrap is disabled,",

--- a/makefile.macosx
+++ b/makefile.macosx
@@ -6,7 +6,7 @@ DEBUG=#-g -D_DEBUG #-pg #-fprofile-arcs
 LDFLAGS=-lpanel -lncurses -lm $(DEBUG)
 CFLAGS=-O2 -D$(shell uname) -DVERSION=\"$(VERSION)\" $(DEBUG) -DCONFIG_FILE=\"$(CONFIG_FILE)\"
 
-OBJS=utils.o mt.o error.o my_pty.o term.o scrollback.o help.o mem.o cv.o selbox.o stripstring.o color.o misc.o ui.o exec.o diff.o config.o cmdline.o globals.o history.o xclip.o
+OBJS=utils.o mt.o error.o my_pty.o term.o scrollback.o help.o mem.o cv.o selbox.o stripstring.o color.o misc.o ui.o exec.o diff.o config.o cmdline.o globals.o history.o clipboard.o
 
 all: multitail
 

--- a/multitail.conf
+++ b/multitail.conf
@@ -994,6 +994,10 @@ check_mail:0
 # to the X clipboard
 #xclip:/usr/bin/xclip
 #
+# where to find the 'pbcopy' binary - used to send a buffer
+# to the clipboard (OSX-only)
+#pbcopy:/usr/bin/pbcopy
+#
 # width of a TAB-character. in the VI editor this is, for
 # example, 8. default in multitail is 4
 tab_stop:8

--- a/scrollback.c
+++ b/scrollback.c
@@ -19,7 +19,7 @@
 #include "ui.h"
 #include "misc.h"
 #include "globals.h"
-#include "xclip.h"
+#include "clipboard.h"
 
 int scrollback_search_to_new_window(buffer *pbuf, char *org_title, char *find_str, mybool_t case_insensitive);
 

--- a/xclip.h
+++ b/xclip.h
@@ -1,4 +1,0 @@
-extern char *xclip;
-
-void send_to_xclip(char *what);
-void send_to_clipboard(buffer *pb);


### PR DESCRIPTION
This is a work-in-progress as a follow-up to #13. I’m opening this PR before finishing it to get feedback. It should work as is but I haven’t tested yet.

I moved `xclip.{c,h}` to `clipboard.{c,h}` and renamed the global variable. I however kept the `xclip` configuration variable not to break people’s config and added a `pbpaste` one for OS X users. Do you think we should use only one `clipboard` config variable?