### PR TITLE
Add support for 256 colors in color schemes

### DIFF
--- a/multitail.conf
+++ b/multitail.conf
@@ -17,8 +17,8 @@
 #
 #             color: [fg],[bg],[attribute[/otherattribute]][|other colorpair+attribute]
 #             e.g.: red,,bold|red would give bold red for line 1 and just red for line 2, etc.
-# Possible colors: red, green, yellow, blue, magenta, cyan and white.
-#
+# Possible colors: red, green, yellow, blue, magenta, cyan and white. 
+# For 256 colors support, you just have to use the color number of the ANSI 256 color scheme.
 #
 # cs_re_s:<color>:<regular expression>
 #             Like cs_re but only the substrings are used(!). E.g.:

--- a/term.c
+++ b/term.c
@@ -699,9 +699,12 @@ int find_or_init_colorpair(int fgcolor, int bgcolor, char ignore_errors)
 	return 0;
 }
 
+
 int colorstr_to_nr(char *str)
 {
 	int loop;
+    int err;
+    regex_t regex_is_color;
 
 	if (str[0] == 0x00) return -1;
 
@@ -710,7 +713,24 @@ int colorstr_to_nr(char *str)
 		if (color_names[loop] && strcmp(color_names[loop], str) == 0)
 			return loop;
 	}
+    
+    err = regcomp(&regex_is_color, "^[[:digit:]]{1,3}$", REG_EXTENDED);
+    if (err == 0) {
+        int match_color;    
+        match_color = regexec(&regex_is_color, str, 0, NULL, 0);
+        regfree(&regex_is_color);
 
+        if (match_color == 0) {
+            int color;
+            char *end;
+            color = strtol(str,&end,10);
+            /* prevent the use of more thant 255 colors */            
+            if (color < 255) {
+                return color;
+            }
+        }
+    }
+    
 	if (use_colors)
 		error_exit(FALSE, FALSE, "'%s' is not recognized as a color\n", str);
 


### PR DESCRIPTION
Hi,

Just a small update to support 256 colors in color schemes (#24) . 

You can now directly call a color by using its number in the scheme file.

Look at https://en.wikipedia.org/wiki/File:Xterm_256color_chart.svg to get the colors codes.

Hope it helps