### PR TITLE
Add a configuration file item to control whether scrollback should de…

### DIFF
--- a/config.c
+++ b/config.c
@@ -1010,6 +1010,11 @@ void set_show_severity_facility(int linenr, char *cmd, char *par)
 	show_severity_facility = config_yes_no(par);
 }
 
+void set_scrollback_fullscreen_default(int linenr, char *cmd, char *par)
+{
+	scrollback_fullscreen_default = config_yes_no(par);
+}
+
 void set_scrollback_no_colors(int linenr, char *cmd, char *par)
 {
 	scrollback_no_colors = config_yes_no(par);
@@ -1101,6 +1106,7 @@ config_file_keyword cf_entries[] = {
 	{ "reuse_searchstring", set_reuse_searchstring },
 	{ "rule", add_filterscheme_rule },
 	{ "scheme", scheme },
+	{ "scrollback_fullscreen_default", set_scrollback_fullscreen_default },
 	{ "scrollback_no_colors", set_scrollback_no_colors },
 	{ "scrollback_search_new_window", set_scrollback_search_new_window },
 	{ "scrollback_show_winnrs", set_scrollback_show_winnrs },

--- a/globals.c
+++ b/globals.c
@@ -145,6 +145,7 @@ char exit_key = 3;
 char default_sb_showwinnr = 0;
 char reuse_searchstring = 1;
 char need_died_procs_check = 0;
+char scrollback_fullscreen_default = 0;
 char scrollback_no_colors = 0;
 char scrollback_search_new_window = 1;
 mybool_t posix_tail = 0;

--- a/globals.h
+++ b/globals.h
@@ -137,6 +137,7 @@ extern mybool_t show_severity_facility;
 extern char *severities[];
 extern char *facilities[];
 extern char *syslog_ts_format;
+extern char scrollback_fullscreen_default;
 extern char scrollback_no_colors;
 extern int syslog_port;
 extern char scrollback_search_new_window;

--- a/multitail.conf
+++ b/multitail.conf
@@ -1273,6 +1273,9 @@ resolv_ip_addresses:yes
 # show severity/facility? not shown in regular syslogd
 show_severity_facility:yes
 #
+# should scrollback default to fullscreen (default is no)
+# scrollback_fullscreen_default:yes
+#
 # suppress colors in the scollback window? this speeds up scrolling a little
 scrollback_no_colors:no
 #


### PR DESCRIPTION
Add a configuration file item to control whether scrollback should default to fullscreen.

New config property is 'scrollback_fullscreen_default' (boolean value expected).
Defaults to 'no' so as to preserve current behavior.

Coincidentally fixes the number of lines being displayed during scrollback in fullscreen mode
(was 6 lines too short).