### PR TITLE
Colorschemes for Apache ColorScheme

### DIFF
--- a/multitail.conf
+++ b/multitail.conf
@@ -229,7 +229,9 @@ cs_re:green:\]
 #
 # apache
 colorscheme:apache:default Apache logging (webserver)
-cs_re:red: 404 
+cs_re:yellow:"[ ]1[0-9][0-9][ ]
+cs_re:green:"[ ][2-3][0-9][0-9][ ]
+cs_re:red:"[ ][4-5][0-9][0-9][ ]
 cs_re:cyan::
 cs_re:green:\[
 cs_re:green:\]


### PR DESCRIPTION
per https://en.wikipedia.org/wiki/List_of_HTTP_status_codes
1xx Informational (Yellow)
2xx, 3xx Success, Redirection (Green)
4xx Client Error (Red)
5xx Server Error (Red)