### PR TITLE
macOS: fix stop_process() not being able to stop processes reliably

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -175,10 +175,10 @@ int mykillpg(pid_t pid, int sigtype)
 /** stop_process
  * - in:      int pid  pid of process
  * - returns: nothing
- * this function sends a TERM-signal to the given process, sleeps for 1009 microseconds
+ * this function sends a TERM-signal to the given process, sleeps for 1000 microseconds
  * and then sends a KILL-signal to the given process if it still exists. the TERM signal
- * is send so the process gets the possibility to gracefully exit. if it doesn't do that
- * in 100 microseconds, it is terminated
+ * is sent so the process gets the possibility to gracefully exit. if it doesn't do that
+ * in 1000 microseconds, it is terminated
  */
 void stop_process(pid_t pid)
 {


### PR DESCRIPTION
multitail version: 1b93e81f3
macOS version: 10.13.4

### before this fix

running `multitail -l "some command"` and exiting with Ctrl-c almost always results in this error:

```shell
$ ./multitail -l "python3 -m http.server 7777"
# press Ctrl-c after the screen shows output from the command, then this error shows:
 --*- multitail 6.4.3 (C) 2003-2014 by folkert@vanheusden.com -*--

The following problem occured:
-----------------------------
Problem stopping child process with PID 98246 (SIGTERM).
If this is a bug, please report the following information:
The last system call returned: 1 which means "Operation not permitted"
 --*- multitail 6.4.3 (C) 2003-2014 by folkert@vanheusden.com -*--

The following problem occured:
-----------------------------
Problem stopping child process with PID 98246 (SIGTERM).
If this is a bug, please report the following information:
The last system call returned: 1 which means "Operation not permitted"

# in case of a single process, multitail does exit with an error but
# we don't leave orphan processes behind
$ ps aux | grep 7777 | grep -v grep
```

If we run two processes, one of them doesn't get properly stopped:

```shell
$ ./multitail -l "python3 -m http.server 7777" -l "python3 -m http.server 8888"
 --*- multitail 6.4.3 (C) 2003-2014 by folkert@vanheusden.com -*--

The following problem occured:
-----------------------------
Problem stopping child process with PID 98265 (SIGTERM).
If this is a bug, please report the following information:
The last system call returned: 1 which means "Operation not permitted"
 --*- multitail 6.4.3 (C) 2003-2014 by folkert@vanheusden.com -*--

The following problem occured:
-----------------------------
Problem stopping child process with PID 98265 (SIGTERM).
If this is a bug, please report the following information:
The last system call returned: 1 which means "Operation not permitted"
$ ps aux | grep python | grep -v grep
ento             98266   0.0  0.1  4263556  13084 s007  S    11:35PM   0:00.16 /usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3\
.6/Resources/Python.app/Contents/MacOS/Python -m http.server 8888
```

(This PR doesn't directly address the issue of orphan processes being left behind; processes get orphaned because mulltitail exits the moment it detects something abnormal in a single `stop_process` function call without sending kill signals to other processes. Fixing the EPERM issue makes it so that `stop_process` doesn't error-exit in the first place.)

### after this fix

`multitail` exits cleanly:

```
$ ./multitail -l "python3 -m http.server 7777"
$ ps aux | grep python | grep -v grep
$ ./multitail -l "python3 -m http.server 7777" -l "python3 -m http.server 8888"
$ ps aux | grep python | grep -v grep
$
```

### what this fix does

macOS apparently returns an EPERM error if you send a kill signal to a process that has been killed once and is waiting for `waitpid()` to reap its exit status (i.e. a zombie process). see:

- https://stackoverflow.com/questions/12521705/why-would-killpg-return-not-permitted-when-ownership-is-correct
- https://bugzilla.mozilla.org/show_bug.cgi?id=1329528

When multitail tries to stop a child process, it sends multiple kill signals in succession to allow the child process to catch the signal and perform any cleanups before exiting. This was in direct conflict with macOS's policy of not allowing kill signals to be sent to zombie processes.

This fix makes the `stop_process()` logic ignore EPERM errors and go through with the steps for ensuring graceful exit of the child process regardless while making sure the process has been stopped in the end (of `stop_process()`). This change is only introduced to apple builds via `#ifdef __APPLE__`.
