### PR TITLE
On Mac, skip killing PID

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -184,11 +184,13 @@ void stop_process(pid_t pid)
 {
 	assert(pid > 1);
 
+#ifndef __APPLE__
 	if (mykillpg(pid, SIGTERM) == -1)
 	{
 		if (errno != ESRCH)
 			error_exit(TRUE, FALSE, "Problem stopping child process with PID %d (SIGTERM).\n", pid);
 	}
+#endif
 
 	usleep(1000);
 


### PR DESCRIPTION
Intended to fix on Mac when using multitail to start multiple programs,
and handle properly when they exit. Example:
  multitail -r 1 -l "foobar" -r 1 -L "foobar -N"

With the patch, it just appends new command output to the previous command output.  (Or it replaces the previous command output if using -R num.)

Without this patch, it prints out and error and halts:

 --*- multitail 6.4.3 (C) 2003-2014 by folkert@vanheusden.com -*--

The following problem occured:
-----------------------------
First Problem stopping child process with PID 39185 (SIGTERM).
If this is a bug, please report the following information:
The last system call returned: 1 which means "Operation not permitted"
 --*- multitail 6.4.3 (C) 2003-2014 by folkert@vanheusden.com -*--

The following problem occured:
-----------------------------
First Problem stopping child process with PID 39185 (SIGTERM).
If this is a bug, please report the following information:
The last system call returned: 1 which means "Operation not permitted"